### PR TITLE
Updated mStable adapter to count all bAsset vault balances

### DIFF
--- a/projects/mstable/abi.json
+++ b/projects/mstable/abi.json
@@ -1,0 +1,52 @@
+{
+  "getBassets": {
+    "constant": true,
+    "inputs": [],
+    "name": "getBassets",
+    "outputs": [{
+        "components": [{
+            "internalType": "address",
+            "name": "addr",
+            "type": "address"
+          },
+          {
+            "internalType": "enum MassetStructs.BassetStatus",
+            "name": "status",
+            "type": "uint8"
+          },
+          {
+            "internalType": "bool",
+            "name": "isTransferFeeCharged",
+            "type": "bool"
+          },
+          {
+            "internalType": "uint256",
+            "name": "ratio",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "maxWeight",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "vaultBalance",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct MassetStructs.Basset[]",
+        "name": "bAssets",
+        "type": "tuple[]"
+      },
+      {
+        "internalType": "uint256",
+        "name": "len",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  }
+}

--- a/projects/mstable/index.js
+++ b/projects/mstable/index.js
@@ -8,19 +8,28 @@ const sdk = require('../../sdk');
 Settings
 ==================================================*/
 
-const mUSD = '0xe2f2a5C287993345a840Db3B0845fbC70f5935a5';
+const abi = require('./abi.json');
+const mUSD_BasketManager = '0x66126B4aA2a1C07536Ef8E5e8bD4EfDA1FdEA96D';
 
 /*==================================================
 Main
 ==================================================*/
 
 async function tvl(timestamp, block) {
-  const totalSupply = (await sdk.api.erc20.totalSupply({
-    target: mUSD,
-    block
-  })).output;
+  const res = await sdk.api.abi.call({
+    block,
+    target: mUSD_BasketManager,
+    abi: abi['getBassets'],
+  });
+  const bAssets = res.output[0];
 
-  return { [mUSD]: totalSupply };
+  const lockedTokens = {};
+
+  bAssets.forEach(b => {
+    lockedTokens[b[0]] = b[5]
+  });
+
+  return lockedTokens;
 }
 
 /*==================================================
@@ -29,7 +38,7 @@ async function tvl(timestamp, block) {
 
 module.exports = {
   name: 'mStable',
-  token: null, // TODO - Add $MTA after launch
+  token: 'MTA',
   category: 'assets',
   start: 1590624000, // May-28-2020 00:00:00
   tvl


### PR DESCRIPTION
Updated existing adapter, changing functionality from simply reading the total supply of mUSD, to listing all the balances of the tokens locked up.

New response:
```
{ 
  '0x6B175474E89094C44Da98b954EedeAC495271d0F': '2958866270079794066',      <-- DAI  (2.95)
  '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48': '9231485780212',            <-- USDC (9.2m)
  '0x0000000000085d4780B73119b644AE5ecd22b376': '910553301805929633300887', <-- TUSD (910k)
  '0xdAC17F958D2ee523a2206206994597C13D831ec7': '12382085843560'            <-- USDT (12.38m)
}
```