### PR TITLE
Number of SNX holders increased from 1000 to 10000

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -518,6 +518,14 @@
         "process": "~0.5.1"
       }
     },
+    "graph-results-pager": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/graph-results-pager/-/graph-results-pager-1.0.2.tgz",
+      "integrity": "sha512-NHhaZMEOwRh+2HfH8suKXs6+MTmsTXNbiS+jJ0r7n5jq7VqAnRXdh/JcYEsVK+oqpTsUIIxGl8uHVqmz/8vtkg==",
+      "requires": {
+        "node-fetch": "2.6.0"
+      }
+    },
     "growl": {
       "version": "1.10.5",
       "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
@@ -855,6 +863,11 @@
         "object.getownpropertydescriptors": "^2.0.3",
         "semver": "^5.7.0"
       }
+    },
+    "node-fetch": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
     },
     "normalize-path": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "bottleneck": "^2.19.5",
     "chai": "^4.2.0",
     "dotenv": "^8.2.0",
+    "graph-results-pager": "^1.0.2",
     "mocha": "^7.0.0",
     "moment": "^2.24.0",
     "shelljs": "^0.8.3",

--- a/projects/synthetix/index.js
+++ b/projects/synthetix/index.js
@@ -5,8 +5,8 @@
   const sdk = require('../../sdk');
   const BigNumber = require('bignumber.js');
   const _ = require('underscore');
-  const axios = require('axios');
   const abi = require('./abi');
+  const pageResults = require('graph-results-pager');
 
 /*==================================================
   Settings
@@ -14,40 +14,61 @@
 
   const snxContract = '0xC011a73ee8576Fb46F5E1c5751cA3B9Fe0af2a6F';
   const stateAddress = '0x4b9Ca5607f1fF8019c1C6A3c2f0CC8de622D5B82';
+  const snxGraphEndpoint = 'https://api.thegraph.com/subgraphs/name/synthetixio-team/synthetix';
 
 /*==================================================
   Main
 ==================================================*/
 
   async function tvl (timestamp, block) {
+
     let totalSNXLocked = new BigNumber(0);
-    const holders = (await axios(`https://api.ethplorer.io/getTopTokenHolders/${snxContract}?apiKey=uxips4087TKQO109&limit=1000`)).data["holders"].map(holder => holder.address);
+
+    const holders = await SNXHolders(block);
+
     const issuanceRatio = (await sdk.api.abi.call({
       block,
       target: stateAddress,
       abi: abi['issuanceRatio']
     })).output;
 
-    const collateral = (await sdk.api.abi.multiCall({
-      block,
-      abi: abi['collateral'],
-      calls: _.map(holders, holder => ({ target: snxContract, params: holder }))
-    })).output;
-
     const ratio = (await sdk.api.abi.multiCall({
       block,
       abi: abi['collateralisationRatio'],
-      calls: _.map(holders, holder => ({ target: snxContract, params: holder }))
+      calls: _.map(holders, holder => ({ target: snxContract, params: holder.id }))
     })).output;
 
     _.forEach(holders, (holder) => {
-      let _collateral = _.find(collateral, result => result.input.params[0] === holder).output;
-      let _ratio = _.find(ratio, result => result.input.params[0] === holder).output;
+      let _collateral = holder.collateral;
+      let _ratio = _.find(ratio, result => result.input.params[0] === holder.id).output;
       let locked = _collateral * Math.min(1, _ratio / issuanceRatio);
       totalSNXLocked = totalSNXLocked.plus(locked);
     });
 
     return { [snxContract]: totalSNXLocked.toFixed() };
+  }
+
+  // Uses graph protocol to run through SNX contract. Since there is a limit of 100 results per query
+  // we can use graph-results-pager library to increase the limit.
+  async function SNXHolders(blockNumber) {
+    return await pageResults({
+      api: snxGraphEndpoint,
+      query: {
+        entity: 'snxholders',
+        selection: {
+          orderBy: 'collateral',
+          orderDirection: 'desc',
+          block : {
+            number : blockNumber
+          },
+          where : {
+            collateral_gt : 0
+          }
+        },
+        properties: ['collateral', 'id'],
+      },
+      max: 10000, // top 10000 SNX holders with collateral. At the time of this commit, there are 51,309 SNX holders. (7/27/2020)
+    });
   }
 
 /*==================================================
@@ -57,7 +78,7 @@
   module.exports = {
     name: 'Synthetix',
     token: 'SNX',
-    category: 'Derivatives',
+    category: 'derivatives',
     start: 1565287200,  // Fri Aug 09 2019 00:00:00
     tvl,
   };


### PR DESCRIPTION
* Uses graph protocol to get more accounts.

before 
```
{
  "ethCallCount": 21,
  "timestamp": 1595894400,
  "block": 10544632,
  "output": {
    "SNX": {
      "balance": "135560675.549697",
      "id": 2586
    }
  }
}
```

after
```
{
  "ethCallCount": 101,
  "timestamp": 1595894400,
  "block": 10544632,
  "output": {
    "SNX": {
      "balance": "158338744.740116",
      "id": 2586
    }
  }
}
```


Test shows around 47087ms per run.
