### PR TITLE
Add all list of yearn v2 and v3 products. Add yvault USDC.

### DIFF
--- a/projects/yearn/abi.json
+++ b/projects/yearn/abi.json
@@ -28,5 +28,20 @@
     "payable": false,
     "stateMutability": "view",
     "type": "function"
+  },
+  "balance" : {
+    "constant": true,
+    "inputs": [],
+    "name": "balance",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
   }
 }

--- a/projects/yearn/index.js
+++ b/projects/yearn/index.js
@@ -11,11 +11,25 @@ const _ = require('underscore');
   ==================================================*/
 
 const yTokenAddresses = [
+  // yearn v2
   '0x16de59092dAE5CcF4A1E6439D611fd0653f0Bd01', // yDAI
   '0xd6aD7a6750A7593E092a9B218d66C0A814a3436e', // yUSDC
+  '0xF61718057901F84C4eEC4339EF8f0D86D2B45600', // ySUSD
+  '0xe6354ed5bc4b393a5aad09f21c46e101e692d447', // yUSDT
+  '0x04Aa51bbcB46541455cCF1B8bef2ebc5d3787EC9', // ywBTC
+
+  // yearn v3
+  '0xc2cb1040220768554cf699b0d863a3cd4324ce32', // yDAI
+  '0x26ea744e5b887e5205727f55dfbe8685e3b21951', // yUSDC
   '0x83f798e925BcD4017Eb265844FDDAbb448f1707D', // yUSDT
-  '0x73a052500105205d34Daf004eAb301916DA8190f'  // yTUSD
+  '0x73a052500105205d34Daf004eAb301916DA8190f', // yTUSD
+  '0x04bc0ab673d88ae9dbc9da2380cb6b79c4bca9ae', // yBUSD
+
 ];
+
+const yVaultAddresses = [
+  '0x597aD1e0c13Bfe8025993D9e79C69E1c0233522e'  // y//USDC
+]
 
 /*==================================================
   TVL
@@ -24,25 +38,29 @@ const yTokenAddresses = [
 async function tvl(timestamp, block) {
   const balances = {};
   const yTokenToUnderlyingToken = {};
+  const yVaultToUnderlyingToken = {};
 
-
-  const underlyingTokenAddressResults = await sdk.api.abi.multiCall({
+  // Get yToken's underlying tokens
+  const underlyingYTokenAddressResults = await sdk.api.abi.multiCall({
     calls: _.map(yTokenAddresses, (address) => ({
       target: address
     })),
     abi: abi["token"]
   });
 
-  _.each(underlyingTokenAddressResults.output, (token) => {
+  _.each(underlyingYTokenAddressResults.output, (token) => {
     if(token.success) {
       const underlyingTokenAddress = token.output;
       const yTokenAddress = token.input.target;
       yTokenToUnderlyingToken[yTokenAddress] = underlyingTokenAddress;
-      balances[underlyingTokenAddress] = 0;
+      if (!balances.hasOwnProperty(underlyingTokenAddress)) {
+        balances[underlyingTokenAddress] = 0;
+      }
     }
   });
 
-  const tokenValueResults = await sdk.api.abi.multiCall({
+  // Calculate yToken's values
+  const yTokenValueResults = await sdk.api.abi.multiCall({
     block,
     calls: _.map(yTokenAddresses, (address) => ({
       target: address
@@ -50,11 +68,47 @@ async function tvl(timestamp, block) {
     abi: abi["calcPoolValueInToken"]
   });
 
-  _.each(tokenValueResults.output, (tokenBalance) => {
+  _.each(yTokenValueResults.output, (tokenBalance) => {
     if(tokenBalance.success) {
       const valueInToken = tokenBalance.output;
       const yTokenAddress = tokenBalance.input.target;
-      balances[yTokenToUnderlyingToken[yTokenAddress]] = valueInToken;
+      balances[yTokenToUnderlyingToken[yTokenAddress]] += valueInToken;
+    }
+  });
+
+  // Get yVault's underlying tokens
+  const underlyingYVaultAddressResults = await sdk.api.abi.multiCall({
+    calls: _.map(yVaultAddresses, (address) => ({
+      target: address
+    })),
+    abi: abi["token"]
+  });
+
+  _.each(underlyingYVaultAddressResults.output, (token) => {
+    if(token.success) {
+      const underlyingTokenAddress = token.output;
+      const yVaultAddress = token.input.target;
+      yVaultToUnderlyingToken[yVaultAddress] = underlyingTokenAddress;
+      if (!balances.hasOwnProperty(underlyingTokenAddress)) {
+        balances[underlyingTokenAddress] = 0;
+      }
+    }
+  });
+
+  // Get yVault's balances in underlying token
+  const yVaultBalanceResults = await sdk.api.abi.multiCall({
+    block,
+    calls: _.map(yVaultAddresses, (address) => ({
+      target: address
+    })),
+    abi: abi["balance"]
+  });
+
+  _.each(yVaultBalanceResults.output, (tokenBalanceResult) => {
+    if(tokenBalanceResult.success) {
+      const valueInToken = tokenBalanceResult.output;
+      const yVaultAddress = tokenBalanceResult.input.target;
+      balances[yVaultToUnderlyingToken[yVaultAddress]] += valueInToken;
     }
   });
 


### PR DESCRIPTION
Currently, TVL only captures yTokens that make up y curve pool. This commit expands the TVL by including other versions of yearn that is used by BUSD pool, or ywBTC. Also adds yvault USDC.

TVL now includes the following 

```
  // yearn v2
  '0x16de59092dAE5CcF4A1E6439D611fd0653f0Bd01', // yDAI
  '0xd6aD7a6750A7593E092a9B218d66C0A814a3436e', // yUSDC
  '0xF61718057901F84C4eEC4339EF8f0D86D2B45600', // ySUSD
  '0xe6354ed5bc4b393a5aad09f21c46e101e692d447', // yUSDT
  '0x04Aa51bbcB46541455cCF1B8bef2ebc5d3787EC9', // ywBTC

  // yearn v3
  '0xc2cb1040220768554cf699b0d863a3cd4324ce32', // yDAI
  '0x26ea744e5b887e5205727f55dfbe8685e3b21951', // yUSDC
  '0x83f798e925BcD4017Eb265844FDDAbb448f1707D', // yUSDT
  '0x73a052500105205d34Daf004eAb301916DA8190f', // yTUSD
  '0x04bc0ab673d88ae9dbc9da2380cb6b79c4bca9ae', // yBUSD

  // yvault
  '0x597aD1e0c13Bfe8025993D9e79C69E1c0233522e'  // y//USDC
```