### PR TITLE
Add OmniBridge to the xDai adapter

### DIFF
--- a/projects/xdai/index.js
+++ b/projects/xdai/index.js
@@ -4,39 +4,68 @@
 
   const sdk = require('../../sdk');
   const _ = require('underscore');
+  const { default: BigNumber } = require('bignumber.js');
 
 /*==================================================
   Settings
   ==================================================*/
 
   const tokenAddresses = [
-    '0x89d24A6b4CcB1B6fAA2625fE562bDD9a23260359', // SAI
-    '0x6B175474E89094C44Da98b954EedeAC495271d0F', // DAI
-    '0x06AF07097C9Eeb7fD685c692751D5C66dB49c215'  // CHAI
+    '0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359', // SAI
+    '0x6b175474e89094c44da98b954eedeac495271d0f', // DAI
+    '0x06af07097c9eeb7fd685c692751d5C66db49c215'  // CHAI
   ];
+  const omniBridge = '0x88ad09518695c6c3712AC10a214bE5109a655671';
+  const xDaiBridge = '0x4aa42145Aa6Ebf72e164C9bBC74fbD3788045016';
 
 /*==================================================
   TVL
   ==================================================*/
 
   async function tvl(timestamp, block) {
-    const balances = {};
+    const balances = {
+      '0x0000000000000000000000000000000000000000': '0'
+    };
 
-    const balanceOfResults = await sdk.api.abi.multiCall({
+    const allTokens = await sdk.api.util.tokenList();
+
+    const balanceOfOmniBridge = block > 10590093
+      ? await sdk.api.abi.multiCall({
+        block,
+        calls: _.map(allTokens, (token) => ({
+          target: token.contract,
+          params: omniBridge
+        })),
+        abi: 'erc20:balanceOf'
+      })
+      : { output: [] };
+
+    const balanceOfXdaiBridge = await sdk.api.abi.multiCall({
       block,
-      calls: _.map(tokenAddresses, (address) => ({
-        target: address,
-        params: '0x4aa42145Aa6Ebf72e164C9bBC74fbD3788045016'
+      calls: _.map(tokenAddresses, (token) => ({
+        target: token,
+        params: xDaiBridge
       })),
       abi: 'erc20:balanceOf'
     });
 
-    _.each(balanceOfResults.output, (balanceOf) => {
+    const output = [
+      ...balanceOfOmniBridge.output,
+      ...balanceOfXdaiBridge.output
+    ];
+
+    _.each(output, (balanceOf) => {
       if(balanceOf.success) {
         const balance = balanceOf.output;
         const address = balanceOf.input.target;
-
-        balances[address] = balance;
+        if (balance === '0') {
+          return;
+        }
+        if (!balances[address]) {
+          balances[address] = balance;
+        } else {
+          balances[address] = new BigNumber(balances[address]).plus(new BigNumber(balance)).toFixed();
+        }
       }
     });
 


### PR DESCRIPTION
This PR updates the xDai adapter with the support of two different bridge contracts:
* xDaiBridge - [0x4aa42145aa6ebf72e164c9bbc74fbd3788045016](https://etherscan.io/address/0x4aa42145aa6ebf72e164c9bbc74fbd3788045016)
* OmniBridge - [0x88ad09518695c6c3712AC10a214bE5109a655671](https://etherscan.io/address/0x88ad09518695c6c3712AC10a214bE5109a655671), [see more details]( https://docs.tokenbridge.net/eth-xdai-amb-bridge/multi-token-extension)

Both of these contracts can be now used for bridging tokens to the xDai chain.