### PR TITLE
Adding CGI balance to Indexcoop TVL

### DIFF
--- a/projects/dpi/index.js
+++ b/projects/dpi/index.js
@@ -1,28 +1,22 @@
 const abi = require('./abi');
 const sdk = require('../../sdk');
 
-const dpiContract = '0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b';
+const assetContracts = {
+  dpi: '0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b',
+  cgi: '0xada0a1202462085999652dc5310a7a9e2bf3ed42'
+};
 
-async function tvl(timestamp, block) {
-  let balances = {};
-
-  // ETH balance
-  let ethBalance = (await sdk.api.eth.getBalance({target: dpiContract, block})).output;
-
-  balances = Object.assign(balances, {
-    '0x0000000000000000000000000000000000000000': ethBalance
-  });
-
+async function getBalances(block, target) {
   // Underlying assets
   let components = (await sdk.api.abi.call({
     block,
-    target: dpiContract,
+    target,
     abi: abi['getComponents'],
   })).output;
 
   let calls = components.map((erc20) => ({
     target: erc20,
-    params: dpiContract
+    params: target
   }));
 
   let componentBalances = (await sdk.api.abi.multiCall({
@@ -31,12 +25,22 @@ async function tvl(timestamp, block) {
     abi: 'erc20:balanceOf'
   })).output;
 
-  let underlyingBalances = componentBalances.reduce((r,o) => Object.assign(r, { [o.input.target]: o.output }), {});
+  return componentBalances.reduce((r,o) => Object.assign(r, { [o.input.target]: o.output }), {});
+};
 
-  balances = Object.assign(balances, underlyingBalances);
+async function tvl(timestamp, block) {
+  let balances = {};
+
+  let dpiBalances = await getBalances(block, assetContracts.dpi);
+
+  // CGI was launched later then DPI, but since we are aggregating two different balances unders one asset
+  // we need to start it from a later timestamp, otherwise the test breaks
+  let cgiBalances = (block >= 11826294 || timestamp >= 1613028914) ? await getBalances(block, assetContracts.cgi) : {};
+
+  balances = Object.assign(balances, dpiBalances, cgiBalances);
 
   return balances;
-}
+};
 
 module.exports = {
   name: 'Index Coop',


### PR DESCRIPTION
Indexcoop launched a new index with Coinshares called CGI recently. For now the underlying balances include WETH, WBTC and DGLD.

Note: DGLD is missing on the final TVL list after symbol conversions. It's probably due to missing asset for the auto-conversion list.