### PR TITLE
Adding IndexCoop ETHx2 FLI

### DIFF
--- a/projects/dpi/index.js
+++ b/projects/dpi/index.js
@@ -5,6 +5,7 @@ const assetContracts = {
   dpi: '0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b',
   cgi: '0xada0a1202462085999652dc5310a7a9e2bf3ed42',
   fli: '0xaa6e8127831c9de45ae56bb1b0d4d4da6e5665bd',
+  mvi: '0x72e364f2abdc788b7e918bc238b21f109cd634d7',
 };
 
 async function getBalances(block, target) {
@@ -41,7 +42,10 @@ async function tvl(timestamp, block) {
   // Same as CGI, we need to start getting balances since the inception timestamp
   let fliBalances = (block >= 12035541 || timestamp >= 1615709597) ? await getBalances(block, assetContracts.fli) : {};
 
-  balances = Object.assign(balances, dpiBalances, cgiBalances, fliBalances);
+  // MVI inception timestamp
+  let mviBalances = (block >= 12184150 || timestamp >= 1617688800) ? await getBalances(block, assetContracts.mvi) : {};
+
+  balances = Object.assign(balances, dpiBalances, cgiBalances, fliBalances, mviBalances);
 
   return balances;
 };

--- a/projects/dpi/index.js
+++ b/projects/dpi/index.js
@@ -3,7 +3,8 @@ const sdk = require('../../sdk');
 
 const assetContracts = {
   dpi: '0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b',
-  cgi: '0xada0a1202462085999652dc5310a7a9e2bf3ed42'
+  cgi: '0xada0a1202462085999652dc5310a7a9e2bf3ed42',
+  fli: '0xaa6e8127831c9de45ae56bb1b0d4d4da6e5665bd',
 };
 
 async function getBalances(block, target) {
@@ -37,7 +38,10 @@ async function tvl(timestamp, block) {
   // we need to start it from a later timestamp, otherwise the test breaks
   let cgiBalances = (block >= 11826294 || timestamp >= 1613028914) ? await getBalances(block, assetContracts.cgi) : {};
 
-  balances = Object.assign(balances, dpiBalances, cgiBalances);
+  // Same as CGI, we need to start getting balances since the inception timestamp
+  let fliBalances = (block >= 12035541 || timestamp >= 1615709597) ? await getBalances(block, assetContracts.fli) : {};
+
+  balances = Object.assign(balances, dpiBalances, cgiBalances, fliBalances);
 
   return balances;
 };


### PR DESCRIPTION
IndexCoop recently launched ETHx2 Flexible Leveraged Index. PR is adding it to the TVL of IndexCoop.

There might be one issue with cETH decimals. In tests the adapter is showing the balance formatted with 18 decimals, but should be 8.

For the MVI following token balances are missing in the TVL:

* waxe (0x7a2Bc711E19ba6aff6cE8246C546E8c4B4944DFD)
* sand (0x3845badAde8e6dFF049820680d1F14bD3903a5d0)
* rfox (0xa1d6df714f91debf4e0802a542e13067f31b8262)
* audio (0x18aAA7115705e8be94bfFEBDE57Af9BFc265B998)
* revv (0x557B933a7C2c45672B610F8954A3deB39a51A8Ca)
* muse (0xb6ca7399b4f9ca56fc27cbff44f4d2e4eef1fc81)
