### PR TITLE
Add: OnX Finance Adapter

### DIFF
--- a/projects/onx/abi.json
+++ b/projects/onx/abi.json
@@ -1,0 +1,16 @@
+{
+  "totalPledge": {
+    "inputs": [],
+    "name": "totalPledge",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  "totalStake": {
+    "inputs": [],
+    "name": "totalStake",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  }
+}

--- a/projects/onx/index.js
+++ b/projects/onx/index.js
@@ -1,0 +1,50 @@
+/*==================================================
+  Modules
+  ==================================================*/
+
+const sdk = require("../../sdk");
+const abi = require("./abi.json");
+
+/*==================================================
+  TVL
+  ==================================================*/
+
+const constant = {
+  lendingPool: {
+    address: "0x47f3e6c1ef0cbe69502167095b592e61de108baa",
+  },
+};
+
+async function tvl(timestamp, block) {
+  const ethSupply = await sdk.api.abi.call({
+    block,
+    target: constant.lendingPool.address,
+    abi: abi["totalStake"],
+  });
+
+  const aEthPledge = await sdk.api.abi.call({
+    block,
+    target: constant.lendingPool.address,
+    abi: abi["totalPledge"],
+  });
+
+  let balances = {
+    "0x0000000000000000000000000000000000000000": ethSupply.output,
+    "0xE95A203B1a91a908F9B9CE46459d101078c2c3cb": aEthPledge.output,
+  };
+
+  return balances;
+}
+
+/*==================================================
+  Exports
+  ==================================================*/
+
+module.exports = {
+  name: "OnX Finance",
+  website: "https://onx.finance",
+  token: "ONX",
+  category: "lending",
+  start: 1614052706, // Feb-23-2021 03:58:26 AM +UTC
+  tvl,
+};


### PR DESCRIPTION
This PR is OnX Adapter to fetch the total ETH supplied and aETH collateral in the OnX Finance Lending Platform.

**Note: aETH token is not supported with run test and validate**