### PR TITLE
Add Sablier

### DIFF
--- a/v2/projects/sablier/index.js
+++ b/v2/projects/sablier/index.js
@@ -1,0 +1,31 @@
+const axios = require("axios");
+
+module.exports = {
+  /* Metadata */
+  name: "Sablier",
+  category: "Payments",
+  start: 1573582731,
+  token: null,
+  tokenHolderMap: [
+    {
+      tokens: async () => {
+        const result = await axios({
+          url: "https://api.thegraph.com/subgraphs/name/sablierhq/sablier",
+          method: "post",
+          data: {
+            query: `
+              query AllTokens {
+                tokens {
+                  id
+                }
+              }
+            `
+          }
+        });
+        const allTokens = result.data.data.tokens;
+        return allTokens.map(token => token.id );
+      },
+      holders: "0xA4fc358455Febe425536fd1878bE67FfDBDEC59a",
+    },
+  ],
+};


### PR DESCRIPTION
Adds [Sablier](https://sablier.finance) by querying our [subgraph](https://thegraph.com/explorer/subgraph/sablierhq/sablier) to get gold of all the tokens that have ever been streamed on Sablier.

Note that the current TVL reporting is off: some of the tokens streaming on Sablier are not part of the DeFi Pulse token API.