### PR TITLE
remove old vaults with incorrect data

### DIFF
--- a/projects/harvest/config.js
+++ b/projects/harvest/config.js
@@ -91,10 +91,7 @@ const liquidityPools = [
   'V_SUSHI_USDC_WETH',
   'V_SUSHI_USDC_WETH_#V1',
   'V_UNI_WETH_MCAT20',
-  'V_SUSHI_WBTC_WETH_#V2',
   'V_SUSHI_WBTC_WETH_#V1',
-  'V_SUSHI_USDC_WETH_#V2',
-  'V_SUSHI_WETH_USDT_#V2',
   'V_SUSHI_DAI_WETH_#V3',
 ]
 


### PR DESCRIPTION
cc Nate, sorry I don't know your Github username!

It looks like these were the vaults that had invalid historical data. And it appears that the only reason this wasn't an issue before is that our old adapter was returning the values with our fTokens as keys, leading to them being silently ignored.

I ran this on a few dates in the offending time range (Jan, Feb, March) but of course would welcome your full testing.