### PR TITLE
Update Fei Adapter

### DIFF
--- a/v2/projects/fei/index.js
+++ b/v2/projects/fei/index.js
@@ -17,6 +17,7 @@ module.exports = {
                 '0xa08A721dFB595753FFf335636674D76C455B275C', // EthReserveStabilizer.sol
                 '0xDa079A280FC3e33Eb11A78708B369D5Ca2da54fE', // EthPCVDripper.sol
                 '0x5d6446880fcd004c851ea8920a628c70ca101117', // EthUniswapPCVDepost.sol
+                '0x9b0C6299D08fe823f2C0598d97A1141507e4ad86', // EthUniswapPCVDeposit.sol (pre-FIP-5)
             ],
         },
   ],


### PR DESCRIPTION
This adapter is missing the address of the old PCV Deposit contract, causing it to have missing data for the beginning of April. Here we add the address of the PCV Deposit contract pre-FIP-5