### PR TITLE
Add frax and ohm-frax pools to Olympus

### DIFF
--- a/v2/projects/olympus/index.js
+++ b/v2/projects/olympus/index.js
@@ -10,6 +10,8 @@ module.exports = {
         tokens: [
           '0x6b175474e89094c44da98b954eedeac495271d0f', // DAI
           '0x34d7d7aaf50ad4944b70b320acb24c95fa2def7c', // SLP-OHM-DAI
+          '0x853d955acef822db058eb8505911ed77f175b99e', // frax
+          '0x2dce0dda1c2f98e0f171de8333c3c6fe1bbf4877', // ohm-frax
         ],
         holders: [
           '0x886CE997aa9ee4F8c2282E182aB72A705762399D', // Treasury 1


### PR DESCRIPTION
Olympus recently added FRAX and OHM-FRAX pools to its treasury. This PR adds those assets to the TVL calculation.