### PR TITLE
Include PSM in MakerDAO TVL

### DIFF
--- a/projects/maker/index.js
+++ b/projects/maker/index.js
@@ -38,9 +38,7 @@ async function getJoins(block) {
     for (let ilk of ilks) {
       if (ilk.output) {
         let name = utils.hexToString(ilk.output);
-        if (name.substr(0, 3) !== 'PSM') {
-          joins[name.toString()] = ilk.input.target
-        }
+        joins[name.toString()] = ilk.input.target
       }
     }
   


### PR DESCRIPTION
Hi,

Other MakerDAO tracking sites include the PSM in the TVL calculation, this PR brings the defipulse value in line with those.

Examples:
https://makerburn.com/#/rundown  (bottom of page)
https://daistats.com/#/overview

