### PR TITLE
[Saddle] Add sUSD meta pool

### DIFF
--- a/v2/projects/saddle/index.js
+++ b/v2/projects/saddle/index.js
@@ -24,6 +24,7 @@ module.exports = {
         '0x956F47F50A910163D8BF957Cf5846D573E7f87CA', // FEI
         '0x853d955aCEf822Db058eb8505911ED77F175b99e', // FRAX
         '0x5f98805A4E8be255a32880FDeC7F6728C6568bA0', // LUSD
+        "0x57Ab1ec28D129707052df4dF418D58a2D46d5f51", // sUSD
       ],
       holders: [
         '0x4f6A43Ad7cba042606dECaCA730d4CE0A57ac62e', // BTC Pool Address
@@ -32,6 +33,7 @@ module.exports = {
         '0xa6018520eaacc06c30ff2e1b3ee2c7c22e64196a', // alETH Pool Address
         '0xC69DDcd4DFeF25D8a793241834d4cc4b3668EAD6', // d4 Pool Address
         '0xaCb83E0633d6605c5001e2Ab59EF3C745547C8C7', // USDv2 Pool Address
+        '0x0C8BAe14c9f9BF2c953997C881BEfaC7729FD314', // sUSD Pool Address
       ],
     }
   ],


### PR DESCRIPTION
This only counts the sUSD in the meta pool to prevent double counting of the other assets.