### PR TITLE
Fixed Fuse TVL

### DIFF
--- a/projects/rari/abi.json
+++ b/projects/rari/abi.json
@@ -24,16 +24,55 @@
     "stateMutability": "view",
     "type": "function"
   },
-  "getRawFundBalances": {
-    "constant": false,
-    "inputs": [],
-    "name": "getRawFundBalances",
+  "getPublicPools": {
+      "inputs": [],
+      "name": "getPublicPools",
+      "outputs": [
+        { "internalType": "uint256[]", "name": "", "type": "uint256[]" },
+        {
+          "components": [
+            { "internalType": "string", "name": "name", "type": "string" },
+            { "internalType": "address", "name": "creator", "type": "address" },
+            {
+              "internalType": "address",
+              "name": "comptroller",
+              "type": "address"
+            },
+            {
+              "internalType": "uint256",
+              "name": "blockPosted",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "timestampPosted",
+              "type": "uint256"
+            }
+          ],
+          "internalType": "struct FusePoolDirectory.FusePool[]",
+          "name": "",
+          "type": "tuple[]"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function",
+      "constant": true
+  },
+  "getPoolSummary": {
+    "inputs": [
+      {
+        "internalType": "contract Comptroller",
+        "name": "comptroller",
+        "type": "address"
+      }
+    ],
+    "name": "getPoolSummary",
     "outputs": [
       { "internalType": "uint256", "name": "", "type": "uint256" },
-      { "internalType": "uint8[]", "name": "", "type": "uint8[]" },
-      { "internalType": "uint256[]", "name": "", "type": "uint256[]" }
+      { "internalType": "uint256", "name": "", "type": "uint256" },
+      { "internalType": "address[]", "name": "", "type": "address[]" },
+      { "internalType": "string[]", "name": "", "type": "string[]" }
     ],
-    "payable": false,
     "stateMutability": "nonpayable",
     "type": "function"
   },
@@ -49,141 +88,6 @@
       { "internalType": "uint256[]", "name": "", "type": "uint256[]" }
     ],
     "payable": false,
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  "getAllPools": {
-    "inputs": [],
-    "name": "getAllPools",
-    "outputs": [
-      {
-        "components": [
-          { "internalType": "string", "name": "name", "type": "string" },
-          { "internalType": "address", "name": "creator", "type": "address" },
-          {
-            "internalType": "address",
-            "name": "comptroller",
-            "type": "address"
-          },
-          {
-            "internalType": "uint256",
-            "name": "blockPosted",
-            "type": "uint256"
-          },
-          {
-            "internalType": "uint256",
-            "name": "timestampPosted",
-            "type": "uint256"
-          }
-        ],
-        "internalType": "struct FusePoolDirectory.FusePool[]",
-        "name": "",
-        "type": "tuple[]"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function",
-    "constant": true
-  },
-  "getPoolAssetsWithData":   {
-    "inputs": [
-      {
-        "internalType": "contract Comptroller",
-        "name": "comptroller",
-        "type": "address"
-      }
-    ],
-    "name": "getPoolAssetsWithData",
-    "outputs": [
-      {
-        "components": [
-          { "internalType": "address", "name": "cToken", "type": "address" },
-          {
-            "internalType": "address",
-            "name": "underlyingToken",
-            "type": "address"
-          },
-          {
-            "internalType": "string",
-            "name": "underlyingName",
-            "type": "string"
-          },
-          {
-            "internalType": "string",
-            "name": "underlyingSymbol",
-            "type": "string"
-          },
-          {
-            "internalType": "uint256",
-            "name": "underlyingDecimals",
-            "type": "uint256"
-          },
-          {
-            "internalType": "uint256",
-            "name": "underlyingBalance",
-            "type": "uint256"
-          },
-          {
-            "internalType": "uint256",
-            "name": "supplyRatePerBlock",
-            "type": "uint256"
-          },
-          {
-            "internalType": "uint256",
-            "name": "borrowRatePerBlock",
-            "type": "uint256"
-          },
-          {
-            "internalType": "uint256",
-            "name": "totalSupply",
-            "type": "uint256"
-          },
-          {
-            "internalType": "uint256",
-            "name": "totalBorrow",
-            "type": "uint256"
-          },
-          {
-            "internalType": "uint256",
-            "name": "supplyBalance",
-            "type": "uint256"
-          },
-          {
-            "internalType": "uint256",
-            "name": "borrowBalance",
-            "type": "uint256"
-          },
-          { "internalType": "uint256", "name": "liquidity", "type": "uint256" },
-          { "internalType": "bool", "name": "membership", "type": "bool" },
-          {
-            "internalType": "uint256",
-            "name": "exchangeRate",
-            "type": "uint256"
-          },
-          {
-            "internalType": "uint256",
-            "name": "underlyingPrice",
-            "type": "uint256"
-          },
-          { "internalType": "address", "name": "oracle", "type": "address" },
-          {
-            "internalType": "uint256",
-            "name": "collateralFactor",
-            "type": "uint256"
-          },
-          {
-            "internalType": "uint256",
-            "name": "reserveFactor",
-            "type": "uint256"
-          },
-          { "internalType": "uint256", "name": "adminFee", "type": "uint256" },
-          { "internalType": "uint256", "name": "fuseFee", "type": "uint256" }
-        ],
-        "internalType": "struct FusePoolLens.FusePoolAsset[]",
-        "name": "",
-        "type": "tuple[]"
-      }
-    ],
     "stateMutability": "nonpayable",
     "type": "function"
   },

--- a/projects/rari/index.js
+++ b/projects/rari/index.js
@@ -51,7 +51,6 @@ async function tvl(timestamp, block) {
       balances[token] = amount
     }
   }
-
   const getBalancesFromEarnPool = async (addresses) => {
     const earnPoolData = (await sdk.api.abi.multiCall({
       calls: addresses.map((address) => ({
@@ -146,11 +145,17 @@ async function tvl(timestamp, block) {
 
       for (let i = 0; i < fusePoolsTokenData.length; i++) {
         const underlyingTokenAddress = fusePoolsTokenData[i][1]
-        const underlyingTokenTotalSupply = BigNumber(fusePoolsTokenData[i][8])
-        if (underlyingTokenTotalSupply.isGreaterThan(bigNumZero)) {
-          updateBalance(underlyingTokenAddress, underlyingTokenTotalSupply)
+        if (fusePoolsTokenData[i][14] === '0') {
+          continue
+        }
+        const exchangeRate = BigNumber(fusePoolsTokenData[i][14])
+        const decimals = BigNumber('1000000000000000000')
+        const underlyingBalance = BigNumber(fusePoolsTokenData[i][7]).multipliedBy(exchangeRate).dividedBy(decimals)
+        if (underlyingBalance.isGreaterThan(bigNumZero)) {
+          updateBalance(underlyingTokenAddress, underlyingBalance)
         }
       }
+
     }
   } catch(e) {
     // ignore error


### PR DESCRIPTION
For 08/17, I get a TVL of 140m and current TVL sits at 138m so i think this is fine. The way that Rari and DefiPulse calculate usd value of token prices is different and can account for this discrepancy.

The one issue is that locally, ETH is reporting to have a price of 0 whereas in reality is is ~3K. I have surfaced this in discord, but will repost here for visibility. The below result was achieved from running `yarn test-tvl -- --project=rari`

``` 
 {
      "contract": "0x0000000000000000000000000000000000000000",
      "symbol": "ETH",
      "balance": 38657.634264633816,
      "price": 0
    },
```

If it's preferred, I'm happy to remove the uses of ETH and just use WETH instead.