### PR TITLE
Pendle: adjust adapater to fit TVL criteria

### DIFF
--- a/v2/projects/pendle/index.js
+++ b/v2/projects/pendle/index.js
@@ -13,19 +13,6 @@ const MARKET_HOLDERS = {
 };
 
 /*
- * For computing TVL in Sushi Liquidity Pools
- */
-const SUSHI_HOLDERS = [
-  '0xb124c4e18a282143d362a066736fd60d22393ef4', // OT-PE-29DEC2022
-  '0x72972b21ce425cfd67935e07c68e84300ce3f40f', // OT-ETHUSDC-29DEC2022
-  '0x8B758d7fD0fC58FCA8caA5e53AF2c7Da5F5F8De1', // OT-aUSDC-30DEC2021
-  '0x0d8a21f2ea15269b7470c347083ee1f85e6a723b', // OT-aUSDC-29DEC2022
-  '0x2C80D72af9AB0bb9D98F607C817c6F512dd647e6', // OT-cDAI-30DEC2021
-  '0x4556C4488CC16D5e9552cC1a99a529c1392E4fe9', // OT-cDAI-29DEC2022
-];
-const HOLDERS = [MARKET_HOLDERS, SUSHI_HOLDERS];
-
-/*
  * For computing TVL in Pendle Yield Token Holders, when
  * underlying yield tokens are tokenized
  */
@@ -39,22 +26,12 @@ const YIELD_TOKENHOLDERS = [
 ];
 const TOKENHOLDER_TOKENS = [
   '0xBcca60bB61934080951369a648Fb03DF4F96263C', // aUSDC
-  '0x4da27a545c0c5B758a6BA100e3a049001de870f5', // stkAave
   '0x5d3a536E4D6DbD6114cc1Ead35777bAB948E3643', // cDAI
-  '0xc00e94Cb662C3520282E6f5717214004A7f26888', // COMP
   '0x6B3595068778DD592e39A122f4f5a5cF09C90fE2', // SUSHI
   '0x37922C69b08BABcCEaE735A31235c81f1d1e8E43', // SushiSwap PENDLE/ETH LP (SLP)
 ];
 
-/*
- * For computing TVL in PENDLE single staking
- */
-const PENDLE_SINGLE_STAKING = ['0x07282F2CEEbD7a65451Fcd268b364300D9e6D7f5']; // PendleSingleStaking
-const PENDLE_TOKEN = ['0x808507121b80c02388fad14726482e061b8da827']; // PENDLE
-
 const PENDLE_TOKEN_TYPE = ['token', 'xyt'];
-const SUSHI_TOKEN_TYPE = ['token0', 'token1'];
-const TOKEN_TYPES = [PENDLE_TOKEN_TYPE, SUSHI_TOKEN_TYPE];
 
 const TOKEN_ABI = {
   inputs: [],
@@ -72,30 +49,22 @@ const TOKEN_ABI = {
 
 let tokenHolders = [];
 
-for (let h in HOLDERS) {
-  for (let name of TOKEN_TYPES[h]) {    
-    let tokenABI = Object.assign({}, TOKEN_ABI);
-    tokenABI.name = name
-    tokenHolders.push({      
-      tokens: {
-        pullFromPools: true,
-        abi: tokenABI,
-      },
-      holders: HOLDERS[h],
-      checkETHBalance: true,
-    });
-  }
+for (let name of PENDLE_TOKEN_TYPE) {    
+  let tokenABI = Object.assign({}, TOKEN_ABI);
+  tokenABI.name = name
+  tokenHolders.push({      
+    tokens: {
+      pullFromPools: true,
+      abi: tokenABI,
+    },
+    holders: MARKET_HOLDERS,
+    checkETHBalance: true,
+  });
 }
 
 tokenHolders.push({
   tokens: TOKENHOLDER_TOKENS,
   holders: YIELD_TOKENHOLDERS,
-  checkETHBalance: false,
-});
-
-tokenHolders.push({
-  tokens: PENDLE_SINGLE_STAKING,
-  holders: PENDLE_TOKEN,
   checkETHBalance: false,
 });
 
@@ -107,4 +76,3 @@ module.exports = {
   start: 1619495760, // 27-April-2021, 3:56:00 AM +UTC 
   tokenHolderMap: tokenHolders
 };
- 


### PR DESCRIPTION
Prices need to be tracked for the following tokens for TVL to be accurate:

For AMM pool derivative tokens:
`0x31654eb46a3a450265c6dfc4fc4fbbfe371e26fe`: YT-cDAI-30DEC2021
`0xFfAf22DB1ff7e4983b57Ca9632f796f68EdedeF9`: YT-aUSDC-30DEC2021
`0xb7deFe73528942793649c0A950Ec528f66159047`: YT-cDAI-29DEC2022
`0xcDb5b940E95C8632dEcDc806B90dD3fC44E699fE`: YT-aUSDC-29DEC2022
`0x311FCB5dB45A3a5876975f8108237F20525Fa7e0`: YT-USDC/ETH_SLP-29DEC2022
`0x49c8aC20dE6409c7e0B8f9867cffD1481D8206c6`: YT-PENDLE/ETH_SLP-29DEC2022

Sushi LP token as it's locked in Pendle contracts for derivative tokenization:
`0x37922c69b08babcceae735a31235c81f1d1e8e43`: PENDLE/ETH SLP