### PR TITLE
add bed and data indices

### DIFF
--- a/projects/dpi/index.js
+++ b/projects/dpi/index.js
@@ -3,10 +3,12 @@ const sdk = require('../../sdk');
 
 const assetContracts = {
   dpi: '0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b',
+  eth_fli: '0xaa6e8127831c9de45ae56bb1b0d4d4da6e5665bd',
+  btc_fli: '0x0b498ff89709d3838a063f1dfa463091f9801c2b',
   cgi: '0xada0a1202462085999652dc5310a7a9e2bf3ed42',
-  fli: '0xaa6e8127831c9de45ae56bb1b0d4d4da6e5665bd',
   mvi: '0x72e364f2abdc788b7e918bc238b21f109cd634d7',
-  flibtc: '0x0b498ff89709d3838a063f1dfa463091f9801c2b'
+  bed: '0x2aF1dF3AB0ab157e1E2Ad8F88A7D04fbea0c7dc6',
+  data: '0x33d63ba1e57e54779f7ddaeaa7109349344cf5f1'
 };
 
 async function getBalances(block, target) {
@@ -16,6 +18,11 @@ async function getBalances(block, target) {
     target,
     abi: abi['getComponents'],
   })).output;
+
+  // Remove DPI as a component from BED index so we don't double count it towards TVL
+  if(target == assetContracts.bed){
+    components = components.filter(function(address) { return address.toLowerCase() !== assetContracts.dpi.toLowerCase();})
+  }
 
   let calls = components.map((erc20) => ({
     target: erc20,
@@ -36,20 +43,26 @@ async function tvl(timestamp, block) {
 
   let dpiBalances = await getBalances(block, assetContracts.dpi);
 
+  // Same as CGI, we need to start getting balances since the inception timestamp
+  let eth_fliBalances = (block >= 12035541 || timestamp >= 1615709597) ? await getBalances(block, assetContracts.eth_fli) : {};
+
+  // btc fli timestamp
+  let btc_fliBalances = (block >= 12375760  || timestamp >= 1620238070) ? await getBalances(block, assetContracts.btc_fli) : {};
+
   // CGI was launched later then DPI, but since we are aggregating two different balances unders one asset
   // we need to start it from a later timestamp, otherwise the test breaks
   let cgiBalances = (block >= 11826294 || timestamp >= 1613028914) ? await getBalances(block, assetContracts.cgi) : {};
 
-  // Same as CGI, we need to start getting balances since the inception timestamp
-  let fliBalances = (block >= 12035541 || timestamp >= 1615709597) ? await getBalances(block, assetContracts.fli) : {};
-
   // MVI inception timestamp
   let mviBalances = (block >= 12184150 || timestamp >= 1617688800) ? await getBalances(block, assetContracts.mvi) : {};
 
-  // btc fli timestamp
-  let btcBalances = (block >= 12375760  || timestamp >= 1620238070) ? await getBalances(block, assetContracts.flibtc) : {};
+  // BED inception timestamp
+  let bedBalances = (block >= 12819917 || timestamp >= 1626210000) ? await getBalances(block, assetContracts.bed) : {};
 
-  balances = Object.assign(balances, dpiBalances, cgiBalances, fliBalances, mviBalances, btcBalances);
+  // DATA inception timestamp
+  let dataBalances = (block >= 13239311  || timestamp >= 1631844000) ? await getBalances(block, assetContracts.data) : {};
+
+  balances = Object.assign(balances, dpiBalances, cgiBalances, eth_fliBalances, mviBalances, btc_fliBalances, bedBalances, dataBalances);
 
   return balances;
 };


### PR DESCRIPTION
Updates the Index Coop adapter to include the following new index products:

1) BED (Bitcoin, Ethereum, DPI)
2) DATA 

Only thing to note that we're doing a bit different here is removing DPI from the component list for BED. This is to ensure we don't double count DPI towards TVL