### PR TITLE
INDEXER_HOST is not an env var option

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,3 @@
 DEFIPULSE_KEY='SDK_KEY_HERE'
 DEFIPULSE_API_URL='http://defipulse-sdk-staging.us-west-1.elasticbeanstalk.com'
 LOG_PROGRESS=true
-INDEXER_HOST='http://defipulse-indexer-sync-server-staging.us-west-1.elasticbeanstalk.com'


### PR DESCRIPTION
INDEXER_HOST does not appear to be in use in this repository. It's already removed from the production branch but not master or staging.