### PR TITLE
`Origin Dollar`: Add missing tokens 

### DIFF
--- a/v2/projects/origindollar/index.js
+++ b/v2/projects/origindollar/index.js
@@ -16,6 +16,8 @@ module.exports = {
                 '0x5d3a536E4D6DbD6114cc1Ead35777bAB948E3643', // cDAI
                 '0xf650c3d88d12db855b8bf7d11be6c55a4e07dcc9', // cUSDT
                 '0x39aa39c021dfbae8fac545936693ac917d5e7563', // cUSDC
+                '0x028171bca77440897b824ca71d1c56cac55b68a3', // aDai
+                '0x4da27a545c0c5b758a6ba100e3a049001de870f5', // stkAAVE (Staked Aave)
             ],
             holders: [
                 '0x9c459eeb3fa179a40329b81c1635525e9a0ef094', // CompoundStrategyProxy.sol


### PR DESCRIPTION
This PR adds Aave tokens to Origin Dollar project. Test run successfully and show the correct balances of the 2 new added tokens: 
<img width="462" alt="Screenshot 2021-12-10 at 17 35 09" src="https://user-images.githubusercontent.com/579910/145610915-45b6130c-5a24-45a4-ad7a-d22c6ef11af3.png">

