### PR TITLE
:construction_worker: ci: Run test-tvl from CI

### DIFF
--- a/.github/workflows/test-tvl.yml
+++ b/.github/workflows/test-tvl.yml
@@ -1,0 +1,25 @@
+name: test-tvl
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - uses: actions/setup-node@v2
+      with:
+        node-version: '10'
+    - run: npm ci
+    - name: test-tvl
+      run: |
+        adapters=$(git diff origin/staging... --name-only | grep v2/projects/ | cut -d / -f3 | sort | uniq)
+        echo adapters to test: $adapters
+        for adapter in $adapters
+          do npm run test-tvl -- --project=$adapter
+        done
+      env:
+        DEFIPULSE_KEY: ${{ secrets.DEFIPULSE_KEY }}
+        DEFIPULSE_API_URL: https://dfp-sdk-staging.defipulse.com

--- a/v2/projects/solace-fi/index.js
+++ b/v2/projects/solace-fi/index.js
@@ -2,7 +2,9 @@
  * Project: solace.fi
  * Chain: Ethereum
  * Tech Lead: Andrew | Solace#4854 @SolaceAndrew andrew@solace.fi leonardishere
- * Docs: https://docs.solace.fi/ https://github.com/solace-fi
+ * Docs:
+ * - https://docs.solace.fi/
+ * - https://github.com/solace-fi
  */
 
 const ADDRESS = {

--- a/v2/projects/volmex-finance/index.js
+++ b/v2/projects/volmex-finance/index.js
@@ -1,6 +1,6 @@
 module.exports = {
     /* Project Metadata */
-    name: 'Volmex Finance', // project name
+    name: 'Volmex Finance',
     token: null, // null, or token symbol if project has a custom token
     category: 'Derivatives', // allowed values as shown on DefiPulse: 'Derivatives', 'DEXes', 'Lending', 'Payments', 'Assets'
     start: 1623344178, // June 10, 2021 04:56:18 PM +UTC (ETHV)


### PR DESCRIPTION
Detect the project of the pull request and run the `test-tvl` command
if relevant.

I've edited two adapters to demonstrate the feature.
The `test-tvl` command got ran against both `solace-fi` and `volmex-finance`.

This is a first iteration which only runs on v2 adapters for now.
It's easy to extend if we're happy with the idea.