### PR TITLE
Revert lookupBlock being hardcoded to staging indexer in cfa78e7add51 ad2a7b16dd923ae303ef81f2c918

### DIFF
--- a/sdk/api.js
+++ b/sdk/api.js
@@ -297,7 +297,7 @@ module.exports = {
     resetEthCallCount: () => util('resetEthCallCount'),
     toSymbols: (data, chain = null) => util('toSymbols', { data, chain }),
     unwrap: (options) => util('unwrap', { ...options }),
-    lookupBlock: _lookupBlock,
+    lookupBlock: (timestamp) => util('lookupBlock', { timestamp }),
     /**
      *
      * @param {Number} block


### PR DESCRIPTION
Hello, this reverts one line of https://github.com/ConcourseOpen/DeFi-Pulse-Adapters/commit/cfa78e7add51ad2a7b16dd923ae303ef81f2c918 which has caused the `sdk.util.lookupBlock` function to be hardcoded to the staging Indexer. Looks like got missed in PR review. Please see
_lookupBlock function: https://github.com/ConcourseOpen/DeFi-Pulse-Adapters/blob/staging/sdk/api.js#L212

and merge soon before production indexer inadvertently points to staging on this utility method.